### PR TITLE
fix: export config type from barrel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { plugin } from './lib/index';
+export type { TypescriptOperationTypesPluginConfig } from './lib/index';


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Exports the config from the top level barrel file

- **What is the current behavior?** (You can also link to an open issue here)

It's only exported from the 'lib', which requires a deep import or annoying inference hacks to get at the underlying type.

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
